### PR TITLE
Guard-Rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,7 @@ group :development do
   gem 'guard-pow', require: false        # Automatically manage Pow applications restart
   gem 'guard-bundler'                    # Automatically install/update gem bundle when needed
   gem 'guard-annotate'                   # Automatically run the annotate gem when needed
+  gem 'guard-rails'                      # Automatically watching on development server
 
   gem 'powder', require: false # Configure POW server easily
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,8 @@ GEM
       guard (>= 2.3.0)
     guard-pow (2.0.0)
       guard (~> 2.0)
+    guard-rails (0.4.7)
+      guard (>= 0.2.2)
     guard-rspec (4.2.7)
       guard (~> 2.1)
       rspec (>= 2.14, < 4.0)
@@ -417,6 +419,7 @@ DEPENDENCIES
   guard-livereload
   guard-migrate
   guard-pow
+  guard-rails
   guard-rspec
   has_scope
   headhunter

--- a/Guardfile
+++ b/Guardfile
@@ -12,6 +12,11 @@ guard :livereload do
   watch(%r{(app/assets/stylesheets/globals)/.+\.css\.(sass|scss)}) { |m| "#{m[1]}/application.css.#{m[2]}" } # It's strange that this rule is needed, it should work without it, see http://blog.55minutes.com/2013/01/lightning-fast-sass-reloading-in-rails-32/#comment-1184644401
 end
 
+guard 'rails' do
+  watch('Gemfile.lock')
+  watch(%r{^(config|lib)/.*})
+end
+
 guard :rspec, cmd: 'spring rspec' do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }


### PR DESCRIPTION
It would be great to have Rails server output and Guard input in the same window. But sadly, `binding.pry` doesn't seem to play well with this, it's simply ignored. So this PR won't be merged until this can be solved.

I opened an issue here: https://github.com/ranmocy/guard-rails/issues/24
