### PR TITLE
Remove default scope (which excluded guests)

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -7,7 +7,7 @@ class Ability
   def initialize(current_user)
     alias_action :create, :read, :update, :destroy, to: :crud
 
-    can :read, User
+    can :read, User, guest: false
 
     if current_user.guest?
       can :create, User

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,9 +44,8 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable,
          :confirmable, :lockable, authentication_keys: [:login]
 
-  default_scope { where(guest: false) }
-
-  scope :guests, -> { unscoped.where(guest: true) }
+  scope :guests,     -> { where(guest: true) }
+  scope :registered, -> { where(guest: false) }
 
   attr_accessor :login
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -11,16 +11,16 @@ describe ApplicationController do
     it 'creates a guest user for a first request' do
       expect {
         get :index
-      }.to change { User.unscoped.count }.from(0).to 1
+      }.to change { User.guests.count }.from(0).to 1
 
-      expect(User.unscoped.last).to be_guest
+      expect(User.guests.last).to be_guest
     end
 
     it 'finds the guest user for a subsequent request' do
       get :index
       expect {
         get :index
-      }.not_to change { User.unscoped.count }
+      }.not_to change { User.guests.count }
     end
 
     it 'creates a new guest user if the previously existing one vanished' do
@@ -31,9 +31,9 @@ describe ApplicationController do
 
       expect {
         get :index
-      }.to change { User.unscoped.count }.from(1).to 2
+      }.to change { User.guests.count }.from(1).to 2
 
-      expect(User.unscoped.last).to be_guest
+      expect(User.last).to be_guest
     end
   end
 end

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -13,9 +13,9 @@ describe RegistrationsController do
                                  password:              'joshjosh',
                                  password_confirmation: 'joshjosh'
                                }
-        }.to change { User.unscoped.count }.from(0).to 1 # A guest is created first, then the "real" user, then the guest is deleted.
+        }.to change { User.count }.from(0).to 1 # A guest is created first, then the "real" user, then the guest is deleted.
 
-        expect(User.unscoped.last).not_to be_guest
+        expect(User.last).not_to be_guest
       end
 
       it "assigns the guest's preferrably keepable data to the new user" do
@@ -27,9 +27,9 @@ describe RegistrationsController do
       it 'does not create a user and does not delete the guest user' do
         expect {
           post 'create', user: {}
-        }.to change { User.unscoped.count }.from(0).to 1 # A guest is created first, but the "real" user was invalid and couldn't be created
+        }.to change { User.guests.count }.from(0).to 1 # A guest is created first, but the "real" user was invalid and couldn't be created
 
-        expect(User.unscoped.last).to be_guest
+        expect(User.last).to be_guest
       end
     end
   end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -7,8 +7,12 @@ describe Ability do
 
     describe 'managing users' do
       it { should     be_able_to(:create,  User) }
+
       it { should     be_able_to(:read,    User.new) }
+      it { should_not be_able_to(:read,    User.new(guest: true)) }
+
       it { should_not be_able_to(:update,  User.new) }
+
       it { should_not be_able_to(:destroy, User.new) }
     end
   end
@@ -21,6 +25,7 @@ describe Ability do
       it { should_not be_able_to(:create,  User) }
 
       it { should     be_able_to(:read,    User.new) }
+      it { should_not be_able_to(:read,    User.new(guest: true)) }
 
       it { should_not be_able_to(:update,  User.new) }
       it { should     be_able_to(:update,  @user) }
@@ -38,6 +43,7 @@ describe Ability do
       it { should     be_able_to(:create,  User) }
 
       it { should     be_able_to(:read,    User.new) }
+      it { should     be_able_to(:read,    User.new(guest: true)) }
 
       it { should     be_able_to(:update,  User.new) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -119,16 +119,25 @@ describe User do
 
   describe 'scopes' do
     describe '.default' do
-      it 'excludes guests' do
+      it 'includes all users' do
         user = create :user
         guest = create :guest
 
-        expect(User.all).to eq [user]
+        expect(User.all).to eq [user, guest]
+      end
+    end
+
+    describe '.registered' do
+      it 'only includes registered users' do
+        user = create :user
+        guest = create :guest
+
+        expect(User.registered).to eq [user]
       end
     end
 
     describe '.guests' do
-      it 'excludes registered users' do
+      it 'only includes guests' do
         user = create :user
         guest = create :guest
 


### PR DESCRIPTION
Associations only work with objects available in the default scope, so e.g. `guest has_many :comments` wouldn't work. So it's better to remove the default scope.
