### PR TITLE
Features/bower rails fix precompilation

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -9,7 +9,7 @@
  * compiled file, but it's generally better to create a new file per style scope.
  *
  *= require_self
- *= require bootstrap
+ *= require bootstrap/dist/css/bootstrap
  */
 
 @import "globals/all"


### PR DESCRIPTION
Require proper path to Bootstrap's css file

``` bash
$ rake assets:precompile
[WARN] table 'Role' doesn't exist. Did you run the migration ? Ignoring rolify config.
bower.js files generated
/usr/bin/bower install 
I, [2014-05-05T16:02:16.451046 #23524]  INFO -- : Writing /home/sergey/src/github/base/public/assets/application-65a02d73183acd6a13048c5e68b91805.js
I, [2014-05-05T16:02:16.602431 #23524]  INFO -- : Writing /home/sergey/src/github/base/public/assets/application-0eb780695e52843f39c559112861100b.css
I, [2014-05-05T16:02:16.622120 #23524]  INFO -- : Writing /home/sergey/src/github/base/public/assets/xray-1d0747cd9f5bc74e8910bb0ea83337e1.js
I, [2014-05-05T16:02:16.630791 #23524]  INFO -- : Writing /home/sergey/src/github/base/public/assets/xray-e19ecc75b331b67b5b84578ab76d2cf5.css

```

https://github.com/42dev/bower-rails/issues/79
