### PR TITLE
Fix issue with redisplay of avatar upload

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,7 +32,7 @@ class ApplicationController < ActionController::Base
   # https://github.com/plataformatec/devise/wiki/How-To:-Allow-users-to-sign-in-using-their-username-or-email-address
   def configure_permitted_parameters
     devise_parameter_sanitizer.for :sign_up do |u|
-      u.permit :name, :email, :password, :password_confirmation, :remember_me, :avatar, :remove_avatar
+      u.permit :name, :email, :password, :password_confirmation, :remember_me, :avatar, :avatar_cache, :remove_avatar
     end
 
     devise_parameter_sanitizer.for :sign_in do |u|
@@ -40,7 +40,7 @@ class ApplicationController < ActionController::Base
     end
 
     devise_parameter_sanitizer.for :account_update do |u|
-      u.permit :name, :email, :password, :password_confirmation, :current_password, :avatar, :remove_avatar
+      u.permit :name, :email, :password, :password_confirmation, :current_password, :avatar, :avatar_cache, :remove_avatar
     end
   end
 

--- a/spec/features/file_upload_spec.rb
+++ b/spec/features/file_upload_spec.rb
@@ -39,8 +39,6 @@ describe 'File upload' do
   end
 
   it 'uses an uploaded file (from the temporary cache) after a re-display and then successful submit of the form' do
-    pending 'Seems to be an issue of Carrierwave, see https://github.com/carrierwaveuploader/carrierwave/issues/1414'
-
     @user = create :user, :with_avatar
     login_as(@user)
 


### PR DESCRIPTION
This should answer carrierwaveuploader/carrierwave#1414.

I may be missing something though, since in that issue it's specifically mentioned that `avatar_cache` was added to the parameter list (which is what this pull request does). I didn't see it anywhere however, and this seems to fix the issue.