### PR TITLE
Optimisting locking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,8 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw] # Timezone Data for T
 
 gem 'wannabe_bool' # Converts strings, integers, etc. intuitively to boolean values
 
+gem 'differ' # A simple gem for generating string diffs
+
 group :doc do
   gem 'sdoc', require: false # bundle exec rake doc:rails generates the API under doc/api.
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,7 @@ GEM
       warden (~> 1.2.3)
     devise-i18n (0.12.1)
     diff-lcs (1.2.5)
+    differ (0.1.2)
     diffy (3.0.7)
     docile (1.1.5)
     easy_translate (0.5.0)
@@ -527,6 +528,7 @@ DEPENDENCIES
   database_cleaner
   devise
   devise-i18n
+  differ
   email_spec
   enumerize
   factory_girl_rails

--- a/app/assets/stylesheets/layout/components/_stale_info.css.sass
+++ b/app/assets/stylesheets/layout/components/_stale_info.css.sass
@@ -1,0 +1,6 @@
+.stale_info
+  td.interim_value,
+  td.new_value
+    img
+      max-width: 100px
+      max-height: 100px

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,7 +24,7 @@ class ApplicationController < ActionController::Base
   # https://github.com/plataformatec/devise/wiki/How-To:-Allow-users-to-sign-in-using-their-username-or-email-address
   def configure_permitted_parameters
     devise_parameter_sanitizer.for :sign_up do |u|
-      u.permit :name, :email, :password, :password_confirmation, :remember_me, :avatar, :avatar_cache, :remove_avatar
+      u.permit :name, :email, :about, :password, :password_confirmation, :remember_me, :avatar, :avatar_cache, :remove_avatar
     end
 
     devise_parameter_sanitizer.for :sign_in do |u|
@@ -32,7 +32,7 @@ class ApplicationController < ActionController::Base
     end
 
     devise_parameter_sanitizer.for :account_update do |u|
-      u.permit :name, :email, :password, :password_confirmation, :current_password, :avatar, :avatar_cache, :remove_avatar
+      u.permit :name, :email, :about, :password, :password_confirmation, :current_password, :avatar, :avatar_cache, :remove_avatar
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,10 @@
+require 'update_lock'
+
 class UsersController < ApplicationController
   before_filter :authenticate_user!, only: [:new, :edit]
   load_and_authorize_resource
   inherit_resources
+  include UpdateLock
   before_filter :add_base_breadcrumbs
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,16 +1,23 @@
 require 'update_lock'
 
-class UsersController < ApplicationController
+class UsersController < InheritedResources::Base
   before_filter :authenticate_user!, only: [:new, :edit]
   load_and_authorize_resource
-  inherit_resources
   include UpdateLock
   before_filter :add_base_breadcrumbs
 
   private
 
   def permitted_params
-    params.permit(user: [:name, :email, :avatar, :avatar_cache, :remove_avatar, :password, :password_confirmation])
+    params.permit(user: [:name,
+                         :email,
+                         :avatar,
+                         :avatar_cache,
+                         :remove_avatar,
+                         :password,
+                         :password_confirmation,
+                         :lock_version
+                       ])
   end
 
   def add_base_breadcrumbs

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,6 +14,7 @@ class UsersController < InheritedResources::Base
                          :avatar,
                          :avatar_cache,
                          :remove_avatar,
+                         :about,
                          :password,
                          :password_confirmation,
                          :lock_version

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -14,6 +14,7 @@
       = f.input :name
       = f.input :email, as: :email, required: true
       = f.input :avatar, as: :upload
+      = f.input :about
 
   / TODO: Put into a container?
   - if devise_mapping.confirmable? && resource.pending_reconfirmation?

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -17,6 +17,7 @@
           = f.input :name
           = f.input :email, required: true
           = f.input :avatar, as: :upload
+          = f.input :about
 
       = panel do |panel|
         = panel.heading do

--- a/app/views/shared/form/_stale_info.html.slim
+++ b/app/views/shared/form/_stale_info.html.slim
@@ -1,0 +1,62 @@
+= f.hidden_field :lock_version
+
+- if f.object.stale_info.any?
+  .stale_info
+    = panel :warning do |panel|
+      = panel.heading do
+        = t '.stale_attributes'
+
+      = panel.body do
+        table.table.table-striped.table-hover
+          thead
+            tr
+              th = t '.attribute'
+              th = t '.interim_value'
+              th = t '.new_value'
+              th = t '.difference'
+
+          tbody
+            - f.object.stale_info.each do |stale_info|
+              tr id="stale_attribute_#{stale_info.input_id}"
+                th.attribute = stale_info.human_attribute_name
+
+                td.interim_value
+                  - case stale_info.type
+                  - when :text
+                    = simple_format h stale_info.interim_value
+                  - when :string
+                    - case stale_info.interim_value
+                    - when AbstractUploader
+                      = image_tag stale_info.interim_value.url
+                    - else
+                      = h stale_info.interim_value
+                  - else
+                    = stale_info.interim_value
+
+                td.new_value
+                  - case stale_info.type
+                  - when :text
+                    = simple_format h stale_info.new_value
+                  - when :string
+                    - case stale_info.new_value
+                    - when AbstractUploader
+                      = image_tag stale_info.new_value.url
+                    - else
+                      = h stale_info.new_value
+                  - else
+                    = stale_info.new_value
+                
+                td.difference
+                  - case stale_info.type
+                  - when :text
+                    = simple_format h Differ.diff_by_line(h(stale_info.new_value), h(stale_info.interim_value)).format_as(:html).html_safe
+                  - when :string
+                    - case stale_info.new_value
+                    - when AbstractUploader
+                      = t '.no_diff_available'
+                    - else
+                      = h Differ.diff_by_word(stale_info.new_value, stale_info.interim_value).format_as(:html).html_safe
+                  - else
+                    = h Differ.diff_by_char(stale_info.new_value.to_s, stale_info.interim_value.to_s).format_as(:html).html_safe
+
+        p = t '.instructions'

--- a/app/views/shared/form/_stale_info.html.slim
+++ b/app/views/shared/form/_stale_info.html.slim
@@ -27,7 +27,7 @@
                   - when :string
                     - case stale_info.interim_value
                     - when AbstractUploader
-                      = image_tag stale_info.interim_value.url
+                      = image_tag stale_info.interim_value.url, alt: t('.interim_image')
                     - else
                       = h stale_info.interim_value
                   - else
@@ -40,7 +40,7 @@
                   - when :string
                     - case stale_info.new_value
                     - when AbstractUploader
-                      = image_tag stale_info.new_value.url
+                      = image_tag stale_info.new_value.url, alt: t('.new_image')
                     - else
                       = h stale_info.new_value
                   - else

--- a/app/views/users/_details.html.slim
+++ b/app/views/users/_details.html.slim
@@ -6,3 +6,9 @@ dl.dl-horizontal
   - if user.avatar?
     dt = User.human_attribute_name :avatar
     dd.avatar = zoomable_image user.avatar, alt: user.name
+
+- if user.about?
+  .about
+    h2 = User.human_attribute_name :about
+
+    = markdown user.about

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -10,6 +10,7 @@
       = f.input :name
       = f.input :email, as: :email, required: true
       = f.input :avatar, as: :upload
+      = f.input :about
 
   - if user.new_record?
     = panel do |panel|

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -1,5 +1,6 @@
 = simple_form_for user, html:    {class: 'form-horizontal'},
                          wrapper: :horizontal_form do |f|
+  == render 'shared/form/stale_info', f: f
 
   = panel do |panel|
     = panel.heading do

--- a/config/locales/activerecord/de.yml
+++ b/config/locales/activerecord/de.yml
@@ -29,6 +29,7 @@ de:
         remember_me: Eingeloggt bleiben
         roles: Rollen
         updated_at: Aktualisiert am
+        about: Über
     models:
       user:
         one: Benutzer

--- a/config/locales/activerecord/en.yml
+++ b/config/locales/activerecord/en.yml
@@ -29,6 +29,7 @@ en:
         remember_me: Remember me
         roles: Roles
         updated_at: Updated at
+        about: About
     models:
       user:
         one: User

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -48,6 +48,14 @@ de:
     form:
       actions:
         toggle_dropdown: Menü umschalten
+      stale_info:
+        stale_attributes: Attribute, welche verändert worden sind
+        no_diff_available: Keine Differenz möglich
+        difference: Differenz
+        attribute: Attribut
+        instructions: Das Formular beinhaltet momentan nur deine Änderungen ("Neuer Wert"). Bitte führe die zwischenzeitlich von einem anderen Benutzer getätigten Änderungen manuell zu den deinen hinzu. Speichere erst, wenn du sicher bist, dass dadurch keine Änderungen ungewollt verloren gehen!
+        interim_value: Zwischenzeitlicher Wert
+        new_value: Neuer Wert
   'true': Ja
   users:
     form:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -14,22 +14,15 @@ de:
       home_page: Zur Startseite springen
       navigation: Zur Navigation springen
     navigation:
-      about: "Über"
-      admin: Admin
       choose_language: Sprache wählen
       content_navigation: Inhaltsnavigation
       current_group: aktuelle Menügruppe
       current_item: aktueller Menüpunkt
-      edit_account: Konto bearbeiten
-      home: Base
-      log_out: Abmelden
       meta_navigation: Benutzernavigation
       navigation: Navigation
       show_account: Konto anzeigen
-      sign_in: Anmelden
       sign_up: Registrieren
       toggle_navigation: Menü
-      user_menu: Benutzer Menü
       you_are_here: Sie befinden sich hier
   pages:
     about:
@@ -49,13 +42,15 @@ de:
       actions:
         toggle_dropdown: Menü umschalten
       stale_info:
-        stale_attributes: Attribute, welche verändert worden sind
-        no_diff_available: Keine Differenz möglich
-        difference: Differenz
         attribute: Attribut
+        difference: Differenz
         instructions: Das Formular beinhaltet momentan nur deine Änderungen ("Neuer Wert"). Bitte führe die zwischenzeitlich von einem anderen Benutzer getätigten Änderungen manuell zu den deinen hinzu. Speichere erst, wenn du sicher bist, dass dadurch keine Änderungen ungewollt verloren gehen!
+        interim_image: Bisheriges Bild
         interim_value: Zwischenzeitlicher Wert
+        new_image: Neues Bild
         new_value: Neuer Wert
+        no_diff_available: Keine Differenz möglich
+        stale_attributes: Attribute, welche verändert worden sind
   'true': Ja
   users:
     form:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,22 +14,15 @@ en:
       home_page: Jump to home page
       navigation: Jump to navigation
     navigation:
-      about: About
-      admin: Admin
       choose_language: Choose language
       content_navigation: Content navigation
       current_group: current menu group
       current_item: current menu item
-      edit_account: Edit account
-      home: Base
-      log_out: Log out
       meta_navigation: User navigation
       navigation: Navigation
       show_account: Show account
-      sign_in: Sign in
       sign_up: Sign up
       toggle_navigation: Menu
-      user_menu: User menu
       you_are_here: You are here
   pages:
     about:
@@ -49,13 +42,15 @@ en:
       actions:
         toggle_dropdown: Toggle dropdown
       stale_info:
-        stale_attributes: Attributes that have been changed
-        no_diff_available: No diff possible
-        difference: Difference
         attribute: Attribute
+        difference: Difference
         instructions: At the time being, the form only contains your changes ("New value"). Please merge the interim changes by the other user manually. Only save, when you are sure, that no changes are abandoned by error!
+        interim_image: Interim image
         interim_value: Interim value
+        new_image: New image
         new_value: New value
+        no_diff_available: No diff possible
+        stale_attributes: Attributes that have been changed
   'true': 'Yes'
   users:
     form:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,14 @@ en:
     form:
       actions:
         toggle_dropdown: Toggle dropdown
+      stale_info:
+        stale_attributes: Attributes that have been changed
+        no_diff_available: No diff possible
+        difference: Difference
+        attribute: Attribute
+        instructions: At the time being, the form only contains your changes ("New value"). Please merge the interim changes by the other user manually. Only save, when you are sure, that no changes are abandoned by error!
+        interim_value: Interim value
+        new_value: New value
   'true': 'Yes'
   users:
     form:

--- a/config/locales/flash/de.yml
+++ b/config/locales/flash/de.yml
@@ -11,6 +11,10 @@ de:
       update:
         alert: "%{resource_name} konnte nicht bearbeitet werden."
         notice: "%{resource_name} wurde erfolgreich bearbeitet."
+        stale: "%{resource_name} wurde zwischenzeitlich geändert. %{stale_info}"
+        stale_attributes_list:
+          one: 'Das sich im Konflikt befindende Feld ist: %{stale_attributes}.'
+          other: 'Die sich im Konflikt befindenden Felder sind: %{stale_attributes}.'
     alert: Alarm
     close: Schliessen %{name}
     notice: Hinweis

--- a/config/locales/flash/en.yml
+++ b/config/locales/flash/en.yml
@@ -11,6 +11,10 @@ en:
       update:
         alert: "%{resource_name} could not be updated."
         notice: "%{resource_name} was successfully updated."
+        stale: "%{resource_name} meanwhile has been changed. %{stale_info}"
+        stale_attributes_list:
+          one: 'The conflicting field is: %{stale_attributes}.'
+          other: 'The conflicting fields are: %{stale_attributes}.'
     alert: Alert
     close: Close %{name}
     notice: Notice

--- a/config/locales/simple_form/de.yml
+++ b/config/locales/simple_form/de.yml
@@ -5,6 +5,7 @@ de:
       default_message: 'Bitte überprüfe die nachfolgenden Probleme:'
     hints:
       user:
+        about: Schreib etwas über dich (Biographie, Interessen, Hobbies...)
         password_confirmation: Gib dein Passwort nochmal ein, um Tippfehler zu vermeiden
     'no': Nein
     remove_file: Existierende Datei entfernen

--- a/config/locales/simple_form/en.yml
+++ b/config/locales/simple_form/en.yml
@@ -5,6 +5,7 @@ en:
       default_message: 'Please review the problems below:'
     hints:
       user:
+        about: Write something about you (biography, interests, hobbies...)
         password_confirmation: Retype your password to avoid typing errors
     'no': 'No'
     remove_file: Remove existing file

--- a/db/migrate/20151014181655_add_lock_version_to_users.rb
+++ b/db/migrate/20151014181655_add_lock_version_to_users.rb
@@ -1,0 +1,5 @@
+class AddLockVersionToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :lock_version, :integer, default: 0
+  end
+end

--- a/db/migrate/20151015091827_add_about_to_users.rb
+++ b/db/migrate/20151015091827_add_about_to_users.rb
@@ -1,0 +1,5 @@
+class AddAboutToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :about, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151014181655) do
+ActiveRecord::Schema.define(version: 20151015091827) do
 
   create_table "roles", force: :cascade do |t|
     t.string   "name"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 20151014181655) do
     t.datetime "updated_at"
     t.string   "avatar"
     t.integer  "lock_version",           default: 0
+    t.text     "about"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(version: 20151014181655) do
     t.datetime "locked_at"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "avatar"
     t.integer  "lock_version",           default: 0
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150409055838) do
+ActiveRecord::Schema.define(version: 20151014181655) do
 
   create_table "roles", force: :cascade do |t|
     t.string   "name"
@@ -45,7 +45,7 @@ ActiveRecord::Schema.define(version: 20150409055838) do
     t.datetime "locked_at"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "avatar"
+    t.integer  "lock_version",           default: 0
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true

--- a/lib/update_lock.rb
+++ b/lib/update_lock.rb
@@ -1,0 +1,77 @@
+class ActiveRecord::Base
+  class StaleInfo # TODO: Struct?!
+    attr_accessor :resource, :attribute, :human_attribute_name, :input_id, :type, :interim_value, :new_value, :difference
+
+    def initialize(options)
+      self.resource             = options[:resource]
+      self.attribute            = options[:attribute]
+      self.human_attribute_name = options[:human_attribute_name]
+      self.input_id             = options[:input_id]
+      self.type                 = options[:type]
+      self.interim_value        = options[:interim_value]
+      self.new_value            = options[:new_value]
+      self.difference           = options[:difference]
+    end
+  end
+
+  def stale_info
+    return @stale_info if @stale_info
+
+    @stale_info = []
+    @stale_info += stale_info_for(self, model_name.to_s.underscore) if persisted? && changed?
+
+    nested_attributes_options.each do |association, value|
+      send(association).each_with_index do |resource, i|
+        prefix = "#{model_name.to_s.underscore}_#{association}_attributes_#{i}"
+        @stale_info += stale_info_for(resource, prefix, nested: true) if resource.persisted? && resource.changed?
+      end
+    end
+
+    @stale_info
+  end
+
+  private
+
+  def stale_info_for(resource, prefix, options = {})
+    options.reverse_merge! nested: false
+    model_name_suffix = options[:nested] ? " (#{resource.class.model_name.human} ##{resource.id})" : ''
+
+    resource.changes.map do |attribute, change|
+      unless ['updated_at', 'lock_version'].include? attribute
+        StaleInfo.new resource:             resource,
+                      attribute:            attribute,
+                      human_attribute_name: "#{resource.class.human_attribute_name(attribute)}#{model_name_suffix}",
+                      input_id:             "#{prefix}_#{attribute}",
+                      type:                 resource.class.columns_hash[attribute].type,
+                      interim_value:        change[0],
+                      new_value:            change[1]
+      end
+    end.compact
+  end
+end
+
+module UpdateLock
+  def update
+    if params[resource_instance_name][:lock_version].blank?
+      raise ActiveRecord::MissingAttributeError, 'Lock version missing'
+    end
+
+    super
+  rescue ActiveRecord::StaleObjectError
+    flash.now[:alert] = t(
+      'flash.actions.update.stale',
+      resource_name: resource.class.model_name.human,
+      stale_info:    t('flash.actions.update.stale_attributes_list',
+        stale_attributes: resource.stale_info.map { |info| info.human_attribute_name }.to_sentence,
+        count:            resource.stale_info.size
+      )
+    )
+
+    # Set lock version to current value in DB so when saving again (after manually solving the conflicts), no StaleObjectError is thrown anymore
+    resource.stale_info.each do |stale_info|
+      stale_info.resource.lock_version = stale_info.resource.class.find(stale_info.resource.id).lock_version
+    end
+
+    render :edit, status: :conflict
+  end
+end

--- a/lib/update_lock.rb
+++ b/lib/update_lock.rb
@@ -1,16 +1,11 @@
 class ActiveRecord::Base
-  class StaleInfo # TODO: Struct?!
-    attr_accessor :resource, :attribute, :human_attribute_name, :input_id, :type, :interim_value, :new_value, :difference
+  class StaleInfo < Struct.new(:resource, :attribute, :human_attribute_name, :input_id, :type, :interim_value, :new_value)
+    attr_accessor :resource, :attribute, :human_attribute_name, :input_id, :type, :interim_value, :new_value
 
     def initialize(options)
-      self.resource             = options[:resource]
-      self.attribute            = options[:attribute]
-      self.human_attribute_name = options[:human_attribute_name]
-      self.input_id             = options[:input_id]
-      self.type                 = options[:type]
-      self.interim_value        = options[:interim_value]
-      self.new_value            = options[:new_value]
-      self.difference           = options[:difference]
+      options.each do |key, value|
+        self.send "#{key}=", value
+      end
     end
   end
 

--- a/lib/update_lock.rb
+++ b/lib/update_lock.rb
@@ -52,6 +52,7 @@ end
 
 module UpdateLock
   def update
+    # TODO: Would be nice to be able to make sure that lock_version is a permitted parameter!
     if params[resource_instance_name][:lock_version].blank?
       raise ActiveRecord::MissingAttributeError, 'Lock version missing'
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     # Ffaker calls need to be in block?! See https://github.com/EmmanuelOga/ffaker/issues/121
     name                  { FFaker::Name.name }
     email                 { FFaker::Internet.email }
+    about                 "This is some very interesting info about me.\n\nI like playing football and reading books.\n\nI work as a web developer."
     password              's3cur3p@ssw0rd'
     password_confirmation 's3cur3p@ssw0rd'
     confirmed_at          Time.now

--- a/spec/features/user/registration/edit_spec.rb
+++ b/spec/features/user/registration/edit_spec.rb
@@ -8,13 +8,14 @@ describe 'Editing account' do
 
   it 'edits the account' do
     visit edit_user_registration_path
-    save_and_open_page
+
     expect(page).to have_active_navigation_items 'User menu', 'Edit account'
     expect(page).to have_breadcrumbs 'Base', 'Edit account'
     expect(page).to have_headline 'Edit account'
 
     fill_in 'user_name',  with: 'gustav'
     fill_in 'user_email', with: 'new-gustav@example.com'
+    fill_in 'user_about', with: 'Some info about me'
 
     attach_file 'user_avatar', dummy_file_path('other_image.jpg')
 

--- a/spec/features/user/registration/edit_spec.rb
+++ b/spec/features/user/registration/edit_spec.rb
@@ -26,7 +26,8 @@ describe 'Editing account' do
       click_button 'Save'
       @user.reload
     } .to  change { @user.name }.to('gustav')
-      .and change { @user.avatar.to_s }
+      .and change { File.basename(@user.avatar.to_s) }.to('other_image.jpg')
+      .and change { @user.about }.to('Some info about me')
       .and change { @user.encrypted_password }
       .and change { @user.unconfirmed_email }.to('new-gustav@example.com')
 

--- a/spec/features/user/registration/edit_spec.rb
+++ b/spec/features/user/registration/edit_spec.rb
@@ -8,7 +8,7 @@ describe 'Editing account' do
 
   it 'edits the account' do
     visit edit_user_registration_path
-
+    save_and_open_page
     expect(page).to have_active_navigation_items 'User menu', 'Edit account'
     expect(page).to have_breadcrumbs 'Base', 'Edit account'
     expect(page).to have_headline 'Edit account'

--- a/spec/features/user/registration/new_spec.rb
+++ b/spec/features/user/registration/new_spec.rb
@@ -12,6 +12,7 @@ describe 'Signing up' do
 
     fill_in 'user_name',                  with: 'newuser'
     fill_in 'user_email',                 with: 'newuser@example.com'
+    fill_in 'user_about',                 with: 'Some info about me'
     fill_in 'user_password',              with: 'somegreatpassword'
     fill_in 'user_password_confirmation', with: 'somegreatpassword'
 

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -36,6 +36,7 @@ describe 'Editing user' do
 
       fill_in 'user_name',  with: 'gustav'
       fill_in 'user_email', with: 'new-gustav@example.com'
+      fill_in 'user_about', with: 'Some info about me'
 
       attach_file 'user_avatar', dummy_file_path('other_image.jpg')
 
@@ -43,7 +44,8 @@ describe 'Editing user' do
         click_button 'Update User'
         @user.reload
       } .to  change { @user.name }.to('gustav')
-        .and change { @user.avatar.to_s }
+        .and change { File.basename(@user.avatar.to_s) }.to('other_image.jpg')
+        .and change { @user.about }.to('Some info about me')
         .and change { @user.unconfirmed_email }.to('new-gustav@example.com')
 
       expect(page).to have_flash 'User was successfully updated.'
@@ -55,6 +57,7 @@ describe 'Editing user' do
       # Change something in the database...
       expect {
         @user.update_attributes! name:   'interim-name',
+                                 about:  "This is some barely interesting info.\n\nI like playing football and reading books.\n\nI don't work as a web developer anymore.",
                                  avatar: File.open(dummy_file_path('image.jpg'))
       }.to change { @user.lock_version }.by 1
 
@@ -66,7 +69,19 @@ describe 'Editing user' do
         @user.reload
       }.not_to change { @user }
 
-      expect(page).to have_flash('User meanwhile has been changed. The conflicting fields are: Name and Profile picture.').of_type :alert
+      expect(page).to have_flash('User meanwhile has been changed. The conflicting fields are: Name, Profile picture, and About.').of_type :alert
+
+      expect(page).to have_css '#stale_attribute_user_name .interim_value', text: 'interim-name'
+      expect(page).to have_css '#stale_attribute_user_name .new_value',     text: 'new-name'
+      expect(page.html).to include '<del class="differ">interim</del><ins class="differ">new</ins>-name'
+
+      expect(page).to have_css '#stale_attribute_user_about .interim_value', text: 'This is some barely interesting info. I like playing football and reading books. I don\'t work as a web developer anymore.'
+      expect(page).to have_css '#stale_attribute_user_about .new_value',     text: 'This is some very interesting info about me. I like playing football and reading books. I work as a web developer.'
+      expect(page.html).to include "<p><del class=\"differ\">This is some barely interesting info.</p>\n\n<p>I like playing football and reading books.</p>\n\n<p>I don't work as a web developer anymore.</del><ins class=\"differ\">This is some very interesting info about me.</p>\n\n<p>I like playing football and reading books.</p>\n\n<p>I work as a web developer.</ins></p>"
+
+      expect(page).to have_css '#stale_attribute_user_avatar .interim_value img[alt="Interim image"]'
+      expect(page).to have_css '#stale_attribute_user_avatar .new_value img[alt="New image"]'
+      expect(page).to have_css '#stale_attribute_user_avatar .difference', text: 'No diff possible'
 
       expect {
         click_button 'Update User'

--- a/spec/features/users/new_spec.rb
+++ b/spec/features/users/new_spec.rb
@@ -10,10 +10,12 @@ describe 'Creating user' do
     expect(page).to have_breadcrumbs 'Base', 'Users', 'Create'
     expect(page).to have_headline 'Create User'
 
-    fill_in 'user_name',                  with: 'newname' # TODO: Don't use input's ID, use label text everywhere! Addendum: really?? Shouldn't we just rely on SimpleForm displaying labels anyways?
+    fill_in 'user_name',                  with: 'newname'
     fill_in 'user_email',                 with: 'somemail@example.com'
+    fill_in 'user_about',                 with: 'Some info about me'
     fill_in 'user_password',              with: 'somegreatpassword'
     fill_in 'user_password_confirmation', with: 'somegreatpassword'
+
     attach_file 'user_avatar', dummy_file_path('other_image.jpg')
     click_button 'Create User'
 

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -16,6 +16,7 @@ describe 'Showing user' do
     within dom_id_selector(@user) do
       expect(page).to have_css '.email',      text: 'donald@example.com'
       expect(page).to have_css '.created_at', text: 'Mon, 15 Jun 2015 14:33:52 +0200'
+      expect(page).to have_css '.about',      text: 'This is some very interesting info about me. I like playing football and reading books. I work as a web developer.'
       expect(page).to have_css '.avatar img[alt="donald"]'
 
       expect(page).to have_link 'Edit'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,6 +8,17 @@ describe User do
     expect(create(:user)).to be_valid
   end
 
+  it 'provides optimistic locking' do
+    user = create :user
+    stale_user = User.find(user.id)
+
+    user.update_attribute :name, 'new-name'
+
+    expect {
+      stale_user.update_attribute :name, 'even-newer-name'
+    }.to raise_error ActiveRecord::StaleObjectError
+  end
+
   describe 'versioning', versioning: true do
     it 'is versioned' do
       is_expected.to be_versioned

--- a/spec/views/users/show_spec.rb
+++ b/spec/views/users/show_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe "users/show", type: :view do
+  it "Doesn't render empty avatar" do
+    assign :user, create(:user, avatar: nil)
+    render
+    expect(rendered).not_to have_selector('.avatar')
+  end
+
+  it "Doesn't render empty about" do
+    assign :user, create(:user, about: nil)
+    render
+    expect(rendered).not_to have_selector('.about')
+  end
+end


### PR DESCRIPTION
Using the optimistic locking of Rails, this PR implements a way of catching `ActiveRecord::StaleObjectError` thrown e.g. by race conditions when updating an object, including a cool diff and merging partial.

![image](https://cloud.githubusercontent.com/assets/1814983/10509385/ce99f5ca-732c-11e5-99d1-ef78cf80b8d3.png)