### PR TITLE
Re-enable Turbolinks

### DIFF
--- a/app/assets/javascripts/a11yify.js
+++ b/app/assets/javascripts/a11yify.js
@@ -1,0 +1,465 @@
+###*
+#
+# jQuery module for accessibility
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2013, 2014 Dylan Barrell
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+###
+
+do (jQuery) ->
+  $politeAnnouncer = jQuery('#jquery-a11yfy-politeannouncer')
+  $assertiveAnnouncer = jQuery('#jquery-a11yfy-assertiveannouncer')
+  methods =
+    showAndFocus: (focus) ->
+      $focus = if focus then jQuery(focus) else focus
+      @each (index, value) ->
+        $this = jQuery(value)
+        $this.show()
+        if $focus and $focus.length
+          if platform == 'iOS'
+            jQuery('body').focus()
+            setTimeout (->
+              $focus.focus()
+              return
+            ), 1000
+          else
+            $focus.focus()
+        return
+    focus: ->
+      @each (index, value) ->
+        $this = jQuery(value)
+        if platform == 'iOS'
+          jQuery('body').focus()
+          setTimeout (->
+            $this.focus()
+            return
+          ), 1000
+        else
+          $this.focus()
+        return
+    validate: (options) ->
+      opts = jQuery.extend({}, jQuery.fn.a11yfy.defaults.validate, options)
+      @each (index, value) ->
+        $this = jQuery(value)
+        vOptions = jQuery.extend({}, opts.validatorOptions,
+          invalidHandler: invalidHandler
+          errorPlacement: errorPlacement
+          showErrors: showErrors)
+
+        errorPlacement = ->
+          # do nothing - overrides default behavior
+          return
+
+        showErrors = ->
+          # do nothing - overrides default behavior
+          return
+
+        invalidHandler = (event, validator) ->
+          `var $this`
+          id = undefined
+          invalidIds = []
+          $this = jQuery(this)
+          $errorSummary = $this.find('.a11yfy-error-summary')
+          $errorSummaryList = jQuery('<ul>')
+          for id of validator.invalid
+            `id = id`
+            if validator.invalid.hasOwnProperty(id)
+              invalidIds.push id
+          # remove any previous validation markup
+          $this.find('a.a11yfy-skip-link').remove()
+          # remove all the old skip links
+          $this.find('.a11yfy-validation-error').removeClass 'a11yfy-validation-error'
+          # Remove old validation errors
+          $this.find('.a11yfy-error-message').remove()
+          # remove the old error messages
+          $errorSummary.empty()
+          jQuery(invalidIds).each (index, invalidId) ->
+            $input = jQuery('#' + invalidId)
+            $label = jQuery('label[for="' + invalidId + '"]')
+            $next = undefined
+            $span = undefined
+            $label.addClass 'a11yfy-validation-error'
+            $input.addClass 'a11yfy-validation-error'
+            # create the summary entry
+            $errorSummaryList.append '<li><a class="a11yfy-skip-link a11yfy-summary-link" href="#' + invalidId + '">' + $label.text() + '</a>' + ' : ' + validator.invalid[invalidId] + '</li>'
+            # add link to the next field with a validation error
+            if index < invalidIds.length - 1 and opts.skipLink
+              $next = jQuery('<a href="#" class="a11yfy-skip-link">')
+              $next.text jQuery.a11yfy.getI18nString('skipToNextError', undefined, jQuery.fn.a11yfy.defaults.strings)
+              $next.attr 'href', '#' + invalidIds[index + 1]
+              if $input.parent()[0].nodeName == 'P'
+                $input.parent().after $next
+              else
+                $input.after $next
+            # Add the error message into the label
+            $span = jQuery('<span class="a11yfy-error-message">')
+            $span.text ' - ' + validator.invalid[invalidId]
+            $label.append $span
+            return
+          if opts.summary
+            # Add the summary to the document
+            $errorSummary.append $errorSummaryList
+          return
+
+        $this.validate vOptions
+        if opts.skipLink
+          $this.delegate 'a.a11yfy-skip-link', 'click', (e) ->
+            $target = jQuery(e.target)
+            jQuery($target.attr('href')).select().focus()
+            e.preventDefault()
+            e.stopPropagation()
+            return
+        $this.children().first().before jQuery('<div class="a11yfy-error-summary" role="alert" aria-live="assertive">')
+        # Add the aria-required attributes to all the input elements that have the required
+        # attribute
+        $this.find('[required]').attr 'aria-required', 'true'
+        return
+    menu: ->
+      @each (index, value) ->
+        $this = jQuery(value)
+        $menu = $this
+        if value.nodeName != 'UL'
+          throw new Error('The menu container must be an unordered list')
+
+        ### First make all anchor tags in the structure non-naturally focussable ###
+
+        $this.find('a').attr 'tabindex', '-1'
+
+        ### Set the roles for the menubar ###
+
+        $this.attr('role', 'menubar').addClass 'a11yfy-top-level-menu'
+
+        ### set the aria attributes and the classes for the sub-menus ###
+
+        $this.find('>li>ul').addClass('a11yfy-second-level-menu').parent().addClass('a11yfy-has-submenu').attr 'aria-haspopup', 'true'
+        $this.find('>li>ul>li>ul').addClass('a11yfy-third-level-menu').parent().addClass('a11yfy-has-submenu').attr 'aria-haspopup', 'true'
+
+        ###
+        # Set up the keyboard and mouse handlers for all the individual menuitems
+        ###
+
+        $this.find('li').each((index, value) ->
+          `var $this`
+
+          ### Set the roles for the sub-menus and the menuitems ###
+
+          $this = jQuery(value)
+          $this.attr
+            'role': 'menuitem'
+            'tabindex': '-1'
+          $this.find('ul').each (index, value) ->
+            jQuery(value).attr 'role', 'menu'
+            return
+          return
+        ).on('keypress', (e) ->
+          `var $this`
+
+          ###
+          # This implements the WAI-ARIA-PRACTICES keyboard functionality where
+          # pressing the key, corresponding to the first letter of a VISIBLE element
+          # will move the focus to the first such element after the currently focussed
+          # element
+          ###
+
+          keyCode = e.charCode or e.which or e.keyCode
+          keyString = String.fromCharCode(keyCode).toLowerCase()
+          ourIndex = -1
+          currentItem = this
+          $this = jQuery(this)
+          $nextItem = undefined
+          $prevItem = undefined
+          $menuitems = $menu.find('li[role="menuitem"]:visible')
+          if keyCode == 9
+            return true
+          $menuitems.each (index, value) ->
+            if value == currentItem
+              ourIndex = index
+            if index > ourIndex and !$nextItem
+              if jQuery(value).text().trim().toLowerCase().indexOf(keyString) == 0
+                if ourIndex != -1
+                  $nextItem = jQuery(value)
+                else if !$prevItem
+                  $prevItem = jQuery(value)
+            return
+          if !$nextItem and $prevItem
+            $nextItem = $prevItem
+          if $nextItem
+            $nextItem.attr('tabindex', '0').focus()
+            $this.attr 'tabindex', '-1'
+            if $nextItem.parent().get(0) != $this.parent().get(0)
+              $this.parent().parent('li').removeClass 'open'
+          e.stopPropagation()
+          return
+        ).on('keydown', (e) ->
+          `var $this`
+
+          ###
+          # This implements the WAI-ARIA-PRACTICES keyboard navigation functionality
+          ###
+
+          keyCode = e.which or e.keyCode
+          handled = false
+          $this = jQuery(this)
+
+          ###
+          # Open a sub-menu and place focus on the first menuitem within it
+          ###
+
+          openMenu = ->
+            if $this.hasClass('a11yfy-has-submenu')
+              $this.addClass('open').find('>ul>li:visible').first().attr('tabindex', '0').focus()
+              $this.attr 'tabindex', '-1'
+            return
+
+          ###
+          # Move the focus to the menuitem preceding the current menuitem
+          ###
+
+          prevInMenu = ->
+            $context = $this
+            $this.attr 'tabindex', '-1'
+            loop
+              if $context.prev().is(':visible')
+                $context.prev().attr('tabindex', '0').focus()
+                return
+              $context = $context.prev()
+              if !$context.prev().length
+                $context = $this.parent().find('>li').last()
+                if $context.is(':visible')
+                  $context.attr('tabindex', '0').focus()
+                  return
+              if $context[0] == $this[0]
+                $this.attr 'tabindex', '0'
+                break
+            return
+
+          ###
+          # Move the focus to the next menuitem after the currently focussed menuitem
+          ###
+
+          nextInMenu = ->
+            $context = $this
+            $this.attr 'tabindex', '-1'
+            loop
+              if $context.next().is(':visible')
+                $context.next().attr('tabindex', '0').focus()
+                return
+              $context = $context.next()
+              if !$context.next().length
+                $context = $this.parent().find('>li').first()
+                if $context.is(':visible')
+                  $context.attr('tabindex', '0').focus()
+                  return
+              if $context[0] == $this[0]
+                $this.attr 'tabindex', '0'
+                break
+            return
+
+          if e.ctrlKey or e.shiftKey or e.altKey or e.metaKey
+            # not interested
+            return
+          switch keyCode
+            # space
+            when 32, 13
+              # enter
+              handled = true
+              if $this.find('>a').length
+                if $this.find('>a')[0].click
+
+                  ### If this is a leaf node, activate it###
+
+                  $this.find('>a')[0].click()
+                else
+                  # This is a hack for PhantomJS
+                  $this.find('>a').first().trigger 'click'
+              else
+
+                ### If it has a sub-menu, open the sub-menu ###
+
+                openMenu()
+            #left
+            when 37, 27
+              #esc
+              handled = true
+              if keyCode == 37 and $this.parent().hasClass('a11yfy-top-level-menu')
+
+                ### If in the menubar, then simply move to the previous menuitem ###
+
+                prevInMenu()
+              else
+                if $this.parent().attr('role') == 'menu'
+                  # this is part of a submenu, set focus on containing li
+                  $this.parent().parent().attr('tabindex', '0').focus().removeClass 'open'
+                  $this.attr 'tabindex', '-1'
+            when 38
+              #up
+              handled = true
+              if $this.parent().hasClass('a11yfy-top-level-menu')
+
+                ### If in the menubar, then open the sub-menu ###
+
+                openMenu()
+              else
+
+                ### If in sub-menu, move to previous element ###
+
+                prevInMenu()
+            when 39
+              #right
+              handled = true
+              if $this.parent().hasClass('a11yfy-top-level-menu')
+
+                ### If in menubar, move to next menuitem ###
+
+                nextInMenu()
+              else
+
+                ### If in sub-menu, open sub-sub-menu ###
+
+                openMenu()
+            when 40
+              #down
+              handled = true
+              if $this.parent().hasClass('a11yfy-top-level-menu')
+
+                ### If in menubar, open sub-menu ###
+
+                openMenu()
+              else
+
+                ### If in sub-menu, move to the next menuitem ###
+
+                nextInMenu()
+          if handled
+            e.preventDefault()
+            e.stopPropagation()
+          true
+        ).on('blur', ->
+        ).on('click', ->
+          `var $this`
+          $this = jQuery(this)
+          if !$this.hasClass('open')
+            $this.addClass 'open'
+          else
+            $this.removeClass 'open'
+          return
+        ).first().attr 'tabindex', '0'
+        # Make the first menuitem in the menubar tab focussable
+        $this.on 'keydown', (e) ->
+
+          ###
+          # This callback handles the tabbing out of the widget
+          ###
+
+          focusInTopMenu = false
+          keyCode = e.which or e.keyCode
+          if e.ctrlKey or e.altKey or e.metaKey
+            # not interested
+            return
+          if keyCode != 9
+            return true
+
+          ### Find out whether we are currently in the menubar ###
+
+          $this.find('>li').each (index, value) ->
+            if jQuery(value).attr('tabindex') == '0'
+              focusInTopMenu = true
+            return
+          if !focusInTopMenu
+
+            ###
+            # If not in the menubar, close sub-menus and set the tabindex of the top item in the
+            # menubar so it receives focus when the user tabs back into the menubar
+            ###
+
+            $this.find('>li li[tabindex=0]').attr 'tabindex', '-1'
+            setTimeout (->
+              # This code is in a setTimeout so that shift tab works correctly AND
+              # because there is a Firefox (Windows) bug that
+              # causes the default event for a TAB to not happen properly if the visibility of the
+              # currently focussed node is chanhed mid event (e.g. removal of the open class)
+              $this.find('li.open').each((index, value) ->
+                if jQuery(value).parent().hasClass('a11yfy-top-level-menu')
+                  jQuery(value).attr 'tabindex', '0'
+                return
+              ).removeClass 'open'
+              return
+            ), 0
+          true
+        return
+  ua = window.navigator.userAgent
+  platform = if ua.match(/iPhone|iPad|iPod/) then 'iOS' else if ua.match(/Mac OS X/) then 'OSX' else if ua.match(/Windows/) then 'Windows' else 'Other'
+
+  jQuery.a11yfy = ->
+
+  jQuery.fn.a11yfy = (method) ->
+    if methods[method]
+      return methods[method].apply(this, Array::slice.call(arguments, 1))
+    else
+      jQuery.error 'Method ' + method + ' does not exist on jQuery.a11yfy'
+    return
+
+  jQuery.fn.a11yfy.defaults =
+    strings: skipToNextError: 'skip to next field with an error'
+    validate:
+      skipLink: true
+      summary: true
+      validatorOptions: {}
+
+  jQuery.a11yfy.getI18nString = (str, values, strings) ->
+    msg = strings[str]
+    v = undefined
+    if values
+      for v of values
+        `v = v`
+        msg = msg.replace('${' + v + '}', values[v])
+    msg
+
+  jQuery.a11yfy.politeAnnounce = (msg) ->
+    $politeAnnouncer.append jQuery('<p>').text(msg)
+    return
+
+  jQuery.a11yfy.assertiveAnnounce = (msg) ->
+    $assertiveAnnouncer.append jQuery('<p>').text(msg)
+    return
+
+  # Add the polite announce div to the page
+  if !$politeAnnouncer or !$politeAnnouncer.length
+    jQuery(document).ready ->
+      $politeAnnouncer = jQuery('<div>').attr(
+        'id': 'jquery-a11yfy-politeannounce'
+        'role': 'log'
+        'aria-live': 'polite'
+        'aria-relevant': 'additions').addClass('offscreen')
+      jQuery('body').append $politeAnnouncer
+      return
+  # Add the polite announce div to the page
+  if !$assertiveAnnouncer or !$assertiveAnnouncer.length
+    jQuery(document).ready ->
+      $assertiveAnnouncer = jQuery('<div>').attr(
+        'id': 'jquery-a11yfy-assertiveannounce'
+        'role': 'log'
+        'aria-live': 'assertive'
+        'aria-relevant': 'additions').addClass('offscreen')
+      jQuery('body').append $assertiveAnnouncer
+      return
+  return

--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -16,6 +16,7 @@
 #= require_self
 #
 # --- Add custom requires under here! ---
+#= require a11yfy
 #= require example_script
 #= require form_accessibilizer
 #= require textarea_fullscreenizer


### PR DESCRIPTION
Turbolinks would be a cool thing.

Possible problems:

- How to announce page reloads to screen readers?
- JAWS+IE seems to have problems with screen refreshs?! => Plötzlich wird immer nur noch "About link" ausgegeben für jedes Element?! => Wäre das ein Killer??
- Could forms also be optimised with Turbolinks?