### PR TITLE
Save pasted images to JPG

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,6 +1,8 @@
 # encoding: utf-8
 
 class ImageUploader < AbstractUploader
+  # convert :jpg
+
   version :thumb do
     process resize_to_fill: [50, 50]
   end
@@ -12,5 +14,6 @@ class ImageUploader < AbstractUploader
   # This is provided because it's not easily possible to add a border around docx exported images (see https://github.com/jgm/pandoc/issues/3043).
   version :print do
     process border: ['black']
+    process quality: 80
   end
 end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,8 +1,8 @@
-# Inspired by https://gist.github.com/artemave/c20e7450af866f5e7735
 require 'mini_magick'
 
 module CarrierWave
   module MiniMagick
+    # Inspired by https://gist.github.com/artemave/c20e7450af866f5e7735
     def border(color)
       manipulate! do |img|
         img.format 'png'
@@ -22,6 +22,15 @@ module CarrierWave
         img.composite(overlay, 'png') do |i|
           i.compose 'Over'
         end
+      end
+    end
+
+    # https://github.com/carrierwaveuploader/carrierwave/wiki/How-to%3A-Specify-the-image-quality
+    def quality(percentage)
+      manipulate! do |img|
+        img.quality(percentage.to_s)
+        img = yield(img) if block_given?
+        img
       end
     end
   end

--- a/db/migrate/20200305115412_save_images_as_jpg.rb
+++ b/db/migrate/20200305115412_save_images_as_jpg.rb
@@ -1,0 +1,30 @@
+class ImageUploader < AbstractUploader
+  def filename
+    "#{mounted_as}.jpg"
+  end
+end
+
+class SaveImagesAsJpg < ActiveRecord::Migration[5.2]
+  def save_as_jpg(model, attribute)
+    model.find_by_sql("SELECT * FROM #{model.to_s.tableize} WHERE #{attribute} <> ''").each do |record|
+      path = File.expand_path "public/uploads/#{record.model_name.to_s.underscore}/#{attribute}/#{record.id}"
+
+      if File.exists? "#{path}/#{attribute}.png"
+        puts "Converting #{path}/#{attribute}.png to jpg"
+        record.send "#{attribute}=", File.open("#{path}/#{attribute}.png")
+      else
+        puts "Could not find #{path}/#{attribute}.png"
+        record.send "remove_#{attribute}=", true
+      end
+      record.save!
+
+      Dir["#{path}/*.png"].each do |file|
+        File.delete file
+      end
+    end
+  end
+
+  def up
+    save_as_jpg User, 'avatar'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_09_102506) do
+ActiveRecord::Schema.define(version: 2020_03_05_115412) do
 
   create_table "codes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title", null: false


### PR DESCRIPTION
Images that are pasted do not have any transparencies, so saving them as PNG doesn't make much sense as it takes a lot of disk space.

In addition, a quality filter is applied to save even more space.