### PR TITLE
Pandoc: Treat raw HTML as text

### DIFF
--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -3,7 +3,7 @@ module MarkdownHelper
   # TODO: Would be great to use the Tilt default mechanism instead!
   def markdown(string)
     string ||= '' # If nil is supplied, Pandoc waits for input and nothing is returned
-    html = PandocRuby.convert(string).strip
+    html = PandocRuby.convert(string, PANDOC_OPTIONS).strip
     
     nokogiri = Nokogiri::HTML::DocumentFragment.parse(html)
 

--- a/config/initializers/pandoc_ruby.rb
+++ b/config/initializers/pandoc_ruby.rb
@@ -8,3 +8,5 @@ PANDOC_PATH = if Rails.env.production?
               end
 
 PandocRuby.pandoc_path = PANDOC_PATH
+
+PANDOC_OPTIONS = {f: 'markdown-raw_html'}

--- a/config/initializers/pandoc_ruby.rb
+++ b/config/initializers/pandoc_ruby.rb
@@ -9,4 +9,6 @@ PANDOC_PATH = if Rails.env.production?
 
 PandocRuby.pandoc_path = PANDOC_PATH
 
+# Maybe there is a more elegant option?
+# See https://stackoverflow.com/questions/65319978/pandocruby-set-default-options-so-they-will-be-used-whenever-i-call-convert
 PANDOC_OPTIONS = {f: 'markdown-raw_html'}

--- a/spec/features/pages/show_spec.rb
+++ b/spec/features/pages/show_spec.rb
@@ -6,6 +6,13 @@ describe 'Showing page' do
     login_as(@user)
   end
 
+  it 'treats raw HTML as text' do
+    expect(PandocRuby).to receive(:convert).with(an_instance_of(String), hash_including(f: 'markdown-raw_html'))
+
+    @page = create :page, content: 'Some content with <em>raw, not interpreted HTML</em>', creator: @user
+    visit page_path(@page)
+  end
+
   it 'displays a page' do
     other_page = create :page, creator: @user, title: 'Some cool other page'
     parent_page = create(:page, creator: @user, title: 'Cool parent page', navigation_title: nil)
@@ -13,7 +20,7 @@ describe 'Showing page' do
     @page = create :page, navigation_title: 'Page test navigation title',
                           images: [create(:image, creator: @user)],
                           lead:   "# Some lead title\n\nAnd some lead stuff. [some alt](@page-#{other_page.id})",
-                          content: "# Some content title\n\nAnd some content stuff.\n\n![Content image](@image-Image test identifier) with a [](@page-#{other_page.id}) and [some alt](@page-#{other_page.id})",
+                          content: "# Some content title\n\nSome content with <em>raw, not interpreted HTML</em>.\n\n![Content image](@image-Image test identifier) with a [](@page-#{other_page.id}) and [some alt](@page-#{other_page.id})",
                           notes:   "# Some notes title\n\nAnd some notes stuff.\n\n![Notes image](@image-Image test identifier) with a [](@page-#{other_page.id}) and [some alt](@page-#{other_page.id})",
                           parent:  parent_page,
                           children: [child_page],
@@ -36,7 +43,7 @@ describe 'Showing page' do
 
       within '.content' do
         expect(page).to have_css 'h2', text: 'Some content title'
-        expect(page).to have_content 'And some content stuff'
+        expect(page).to have_content 'Some content with <em>raw, not interpreted HTML</em>'
         expect(page).to have_css "img[alt='Content image'][src='#{@page.images.last.file.url}']"
         expect(page).to have_css "a[href='/en/pages/#{other_page.id}']", text: 'Some cool other page'
         expect(page).to have_css "a[href='/en/pages/#{other_page.id}'][title='Some cool other page']", text: 'some alt'


### PR DESCRIPTION
Works, but is a bit smelly... Maybe there's a better way to do this? See https://stackoverflow.com/questions/65319978/pandocruby-set-default-options-so-they-will-be-used-whenever-i-call-convert